### PR TITLE
Release v9.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # 更新日志 / Changelog
 
-## Unreleased
+## v9.2.10 — Observability Side-Channel
 
 - **可观测性侧边信道**：`processInput()` 现在会可选返回 `observability`，但仍严格把它放在 `replyEnvelope` 之外，不让观测和控制混成第二套主接口。
 - **层间对账视图**：新增 `stateReconciliation`，让当前 turn、writeback、session bridge、persisted relationship 的优先级与生效层次可直接读取，不再要求宿主自己拼推导。
 - **策略理由结构体**：新增 `decisionRationale`，用触发条件、候选 profile、接受结果说明为什么这轮落在 `work` 或 `private`，减少“看得见结果、看不见理由”的黑箱感。
+
+**测试：1309 个，0 失败**
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "psyche-ai",
-  "version": "9.2.9",
+  "version": "9.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "psyche-ai",
-      "version": "9.2.9",
+      "version": "9.2.10",
       "license": "MIT",
       "bin": {
         "psyche": "dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psyche-ai",
-  "version": "9.2.9",
+  "version": "9.2.10",
   "description": "AI-first subjectivity kernel for agents with continuous appraisal, relation dynamics, and adaptive reply loops",
   "mcpName": "io.github.Shangri-la-0428/psyche-ai",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump package version from 9.2.9 to 9.2.10
- promote the observability side-channel changelog entry into a formal release section
- prepare the public branch state for npm publish and GitHub release

## Notes
- no runtime code changes beyond what already landed in main through PR #14
- this PR only carries release metadata
