### PR TITLE
feat: proprioception v11.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 更新日志 / Changelog
 
+## v11.7.0 — Proprioception
+
+- **Self-trajectory awareness (proprioception)** — the system can now perceive its own state trajectory and respond to it.
+- **Decline/spiral detection** — when dimensions decline monotonically for 4+ turns, a gentle stabilization nudge is applied (awareness, not correction).
+- **Growth detection** — when dimensions show sustained increase above baseline, the baseline shifts upward (anti-fragility).
+- **Trajectory signals in status summary** — surfaces a compass indicator when anomaly detected.
+- **Zero overhead when healthy** — no extra tokens in normal operation; ~30 chars added to status only when trajectory anomaly is active.
+
 ## v11.6.1 — Slim MCP Response
 
 - **Slim process_input response** — MCP tool returns only what the LLM host needs: `directive`, `stimulus`, `maxTokens`, `requireConfirmation`. Full structured state (ReplyEnvelope, appraisal, observability) available on demand via `psyche://turn/envelope` and `psyche://turn/observability` resources.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psyche-ai",
-  "version": "11.6.1",
+  "version": "11.7.0",
   "description": "AI-first subjectivity kernel for agents with continuous appraisal, relation dynamics, and adaptive reply loops",
   "mcpName": "io.github.Shangri-la-0428/psyche-ai",
   "type": "module",

--- a/src/core.ts
+++ b/src/core.ts
@@ -52,6 +52,8 @@ import { buildTurnObservability } from "./observability.js";
 import { DEFAULT_RELATIONSHIP_USER_ID, resolveRelationshipUserId } from "./relationship-key.js";
 import { normalizeAmbientPriors } from "./ambient-priors.js";
 import { normalizeWritebackSignals } from "./writeback-signals.js";
+import { detectTrajectory } from "./proprioception.js";
+import type { TrajectorySignal } from "./proprioception.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -331,6 +333,10 @@ export class PsycheEngine {
     confidence: number;
     overrideWindow: ResponseContract["overrideWindow"];
   } | null = null;
+  /** Proprioception cooldown — turns remaining before next trajectory check */
+  private proprioceptionCooldown = 0;
+  /** Last detected trajectory signal (in-memory only, for status summary) */
+  private lastTrajectory: TrajectorySignal | null = null;
 
   constructor(config: PsycheEngineConfig = {}, storage: StorageAdapter) {
     this.traits = config.traits;
@@ -608,6 +614,45 @@ export class PsycheEngine {
       if (appliedStimulus) {
         state = applyRelationshipDrift(state, appliedStimulus, opts?.userId);
       }
+
+      // ── Proprioception: self-trajectory awareness ──────────
+      if (this.proprioceptionCooldown > 0) {
+        this.proprioceptionCooldown--;
+      } else {
+        const trajectory = detectTrajectory(state.stateHistory ?? [], state.baseline);
+        this.lastTrajectory = trajectory;
+
+        if (trajectory.kind === "decline" || trajectory.kind === "spiral") {
+          // Gentle awareness nudge — not correction, just noticing
+          if (trajectory.stabilize) {
+            state = {
+              ...state,
+              current: {
+                ...state.current,
+                order: clamp(state.current.order + (trajectory.stabilize.order ?? 0)),
+                flow: clamp(state.current.flow + (trajectory.stabilize.flow ?? 0)),
+                boundary: clamp(state.current.boundary + (trajectory.stabilize.boundary ?? 0)),
+                resonance: clamp(state.current.resonance + (trajectory.stabilize.resonance ?? 0)),
+              },
+            };
+          }
+          this.proprioceptionCooldown = 3;
+        } else if (trajectory.kind === "growth" && trajectory.baselineShift) {
+          // Growth detected — shift baseline upward
+          const shift = trajectory.baselineShift;
+          state = {
+            ...state,
+            baseline: {
+              order: clamp(state.baseline.order + (shift.order ?? 0)),
+              flow: clamp(state.baseline.flow + (shift.flow ?? 0)),
+              boundary: clamp(state.baseline.boundary + (shift.boundary ?? 0)),
+              resonance: clamp(state.baseline.resonance + (shift.resonance ?? 0)),
+            },
+          };
+          this.proprioceptionCooldown = 3;
+        }
+      }
+
       this.lastCompatibilityAssessment = {
         legacyStimulus: appliedStimulus,
         confidence: perception.confidence,
@@ -1310,7 +1355,13 @@ export class PsycheEngine {
       ? ` | \u26A0\uFE0F${hungryDrives.join(",")}`
       : "";
 
+    // Proprioception: surface trajectory awareness
+    const trajectory = this.lastTrajectory ?? detectTrajectory(state.stateHistory ?? [], state.baseline);
+    const trajectoryNote = trajectory.description
+      ? ` | \u{1F9ED}${trajectory.description}`
+      : "";
+
     const sigilTag = state.meta.sigilId ? ` | sigil:${state.meta.sigilId}` : "";
-    return `${emoji} ${emotion} | flow:${Math.round(flow)} order:${Math.round(order)}${driveWarning}${sigilTag}`;
+    return `${emoji} ${emotion} | flow:${Math.round(flow)} order:${Math.round(order)}${driveWarning}${trajectoryNote}${sigilTag}`;
   }
 }

--- a/src/proprioception.ts
+++ b/src/proprioception.ts
@@ -1,0 +1,149 @@
+// ============================================================
+// Proprioception — Self-Trajectory Awareness
+//
+// Perception turned inward. The system perceives its own state
+// trajectory as input, the same way it perceives external stimuli.
+//
+// Two signals:
+//   decline/spiral → gentle awareness (order↑1, boundary↑1)
+//   growth         → baseline upshift (10% of sustained gain)
+//
+// Not a monitor. Not a correction. Just: the system can see itself.
+// ============================================================
+
+import type { SelfState, StateSnapshot } from "./types.js";
+import { DIMENSION_KEYS } from "./types.js";
+
+// ── Constants ───────────────────────────────────────────────
+
+/** Minimum snapshots needed to detect a trajectory */
+const MIN_WINDOW = 4;
+
+/** Per-step change threshold to count as meaningful decline */
+const DECLINE_STEP = -1;
+
+/** Per-step change threshold to count as meaningful growth */
+const GROWTH_STEP = 1;
+
+/** Maximum stabilization nudge per dimension (awareness, not correction) */
+const STABILIZE_MAX = 1.5;
+
+/** Fraction of sustained gain that becomes new baseline */
+const GROWTH_BASELINE_RATIO = 0.1;
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface TrajectorySignal {
+  /** null = no signal, system is fine */
+  kind: "decline" | "growth" | "spiral" | null;
+  /** Which dimensions triggered the signal */
+  dimensions: (keyof SelfState)[];
+  /** Signal strength, 0–1 */
+  magnitude: number;
+  /** Gentle state nudge for decline/spiral (additive) */
+  stabilize: Partial<Record<keyof SelfState, number>> | null;
+  /** Baseline shift for growth (additive) */
+  baselineShift: Partial<Record<keyof SelfState, number>> | null;
+  /** One-line description for status summary */
+  description: string | null;
+}
+
+const NO_SIGNAL: TrajectorySignal = {
+  kind: null, dimensions: [], magnitude: 0,
+  stabilize: null, baselineShift: null, description: null,
+};
+
+// ── Core ────────────────────────────────────────────────────
+
+/**
+ * Detect trajectory patterns from recent state history.
+ * Pure function — no side effects, no persistence.
+ */
+export function detectTrajectory(
+  history: StateSnapshot[],
+  baseline: SelfState,
+): TrajectorySignal {
+  if (history.length < MIN_WINDOW) return NO_SIGNAL;
+
+  const window = history.slice(-MIN_WINDOW);
+  const declining: (keyof SelfState)[] = [];
+  const growing: (keyof SelfState)[] = [];
+
+  for (const dim of DIMENSION_KEYS) {
+    const values = window.map(s => s.state[dim as keyof SelfState] as number);
+    const deltas: number[] = [];
+    for (let i = 1; i < values.length; i++) {
+      deltas.push(values[i] - values[i - 1]);
+    }
+
+    if (deltas.every(d => d < DECLINE_STEP)) {
+      declining.push(dim as keyof SelfState);
+    }
+
+    if (deltas.every(d => d > GROWTH_STEP) && values[values.length - 1] > baseline[dim as keyof SelfState]) {
+      growing.push(dim as keyof SelfState);
+    }
+  }
+
+  // ── Spiral: 2+ dimensions declining together ──
+
+  if (declining.length >= 2) {
+    const totalDrop = declining.reduce((sum, dim) => {
+      const vals = window.map(s => s.state[dim] as number);
+      return sum + Math.abs(vals[vals.length - 1] - vals[0]);
+    }, 0);
+
+    const stabilize: Partial<Record<keyof SelfState, number>> = {};
+    for (const dim of declining) {
+      stabilize[dim] = STABILIZE_MAX;
+    }
+
+    return {
+      kind: "spiral",
+      dimensions: declining,
+      magnitude: Math.min(1, totalDrop / 40),
+      stabilize,
+      baselineShift: null,
+      description: `spiral: ${declining.join("+")} declining ${window.length} turns`,
+    };
+  }
+
+  // ── Single dimension decline ──
+
+  if (declining.length === 1) {
+    const dim = declining[0];
+    const vals = window.map(s => s.state[dim] as number);
+    const drop = Math.abs(vals[vals.length - 1] - vals[0]);
+
+    return {
+      kind: "decline",
+      dimensions: declining,
+      magnitude: Math.min(1, drop / 20),
+      stabilize: { [dim]: STABILIZE_MAX * 0.5 },
+      baselineShift: null,
+      description: `${String(dim)} declining ${window.length} turns (-${drop.toFixed(1)})`,
+    };
+  }
+
+  // ── Growth: sustained increase above baseline ──
+
+  if (growing.length > 0) {
+    const baselineShift: Partial<Record<keyof SelfState, number>> = {};
+    for (const dim of growing) {
+      const vals = window.map(s => s.state[dim] as number);
+      const gain = vals[vals.length - 1] - vals[0];
+      baselineShift[dim] = gain * GROWTH_BASELINE_RATIO;
+    }
+
+    return {
+      kind: "growth",
+      dimensions: growing,
+      magnitude: Math.min(1, growing.length / 4),
+      stabilize: null,
+      baselineShift,
+      description: `growth: ${growing.join("+")} sustained increase`,
+    };
+  }
+
+  return NO_SIGNAL;
+}


### PR DESCRIPTION
## Summary
- Add `proprioception.ts` — self-trajectory awareness via `detectTrajectory()`
- Detect decline/spiral/growth patterns in state history
- Gentle stabilization nudge on decline (+1.5 max), baseline upshift on growth
- Anti-fragile: doesn't prevent evolution, enables leveling up

## Test plan
- [x] 1501 tests pass
- [ ] Merge and publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)