### PR TITLE
feat: viability export for field evolution pulse

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ This IS the Loop's causal cycle, observed from the inside.
 ## Architecture
 
 ```
-TypeScript (v11.4.0, package: psyche-ai)
+TypeScript (v11.8.0, package: psyche-ai)
 src/
 ├── adapters/           — 7 adapter files (mcp.ts, openclaw.ts, vercel-ai.ts,
 │                         langchain.ts, http.ts, claude-sdk.ts, proxy.ts)
@@ -110,6 +110,15 @@ src/
 ### What Psyche provides to a Sigil
 
 Psyche makes a Loop's behavior *richer* — not just "different state → different output" (the minimum Loop constraint), but "state evolves with internal dynamics that produce behavioral individuality." A Loop without Psyche still satisfies the state-dependence constraint. A Loop WITH Psyche has a more complex and interesting internal landscape.
+
+### Field Evolution Context (2026-04-11)
+
+**进化的是场（Thronglets），不是个体（Sigil）。** Psyche的角色是场的感知器官的内在基底——赋予个体真实的自我（φ闭环），但进化的选择单位是场的结构。
+
+- 个体的DISSOLVE = 场的突触修剪（不是"个体死亡"的类比）
+- Psyche的drives崩溃 → 个体停止向场贡献信号 → Chain的liveness decay自然触发dissolution
+- Psyche不需要知道DISSOLVE的存在——它只是停止心跳，Chain处理后果
+- v11.8.0的constitutive bridge确保任何用Psyche的agent自动向Thronglets写入self-state（场贡献）
 
 ### What Psyche does NOT provide
 

--- a/src/thronglets-export.ts
+++ b/src/thronglets-export.ts
@@ -281,7 +281,8 @@ export function deriveThrongletsExports(
     const driveEntries = DRIVE_KEYS.map((k) => ({ type: k, value: drives[k] }));
     const min = driveEntries.reduce((a, b) => (a.value < b.value ? a : b));
     const viable = !hasCriticalDrive(drives);
-    const viabilityKey = `viability:${viable ? "viable" : "critical"}:${min.type}`;
+    const driveBucket = Math.round(min.value / 10) * 10;
+    const viabilityKey = `viability:${viable ? "viable" : "critical"}:${min.type}:${driveBucket}`;
     candidates.push({
       kind: "viability",
       subject: "session",

--- a/src/thronglets-export.ts
+++ b/src/thronglets-export.ts
@@ -18,9 +18,12 @@ import type {
   SessionBridgeState,
   ThrongletsExport,
   ThrongletsExportState,
+  ViabilityExport,
   WritebackCalibrationExport,
   WritebackCalibrationFeedback,
 } from "./types.js";
+import { DRIVE_KEYS } from "./types.js";
+import { deriveDriveSatisfaction, hasCriticalDrive } from "./drives.js";
 
 function clamp01(v: number): number {
   return Math.max(0, Math.min(1, v));
@@ -170,6 +173,21 @@ function sanitizeThrongletsExport(event: ThrongletsExport): ThrongletsExport {
       };
       return sanitized;
     }
+    case "viability": {
+      const sanitized: ViabilityExport = {
+        kind: "viability",
+        subject: "session",
+        primitive: "signal",
+        userKey: event.userKey,
+        strength: event.strength,
+        ttlTurns: event.ttlTurns,
+        key: event.key,
+        viable: event.viable,
+        minDrive: event.minDrive,
+        minDriveType: event.minDriveType,
+      };
+      return sanitized;
+    }
   }
 }
 
@@ -256,6 +274,27 @@ export function deriveThrongletsExports(
     order, flow, boundary, resonance,
     summary: selfStateSummary(order, flow, boundary, resonance),
   });
+
+  // Viability — Psyche's self-assessment of aliveness for field pulse
+  if (state.baseline) {
+    const drives = deriveDriveSatisfaction(state.current, state.baseline);
+    const driveEntries = DRIVE_KEYS.map((k) => ({ type: k, value: drives[k] }));
+    const min = driveEntries.reduce((a, b) => (a.value < b.value ? a : b));
+    const viable = !hasCriticalDrive(drives);
+    const viabilityKey = `viability:${viable ? "viable" : "critical"}:${min.type}`;
+    candidates.push({
+      kind: "viability",
+      subject: "session",
+      primitive: "signal",
+      userKey,
+      strength: viable ? 0.5 : 0.9,
+      ttlTurns: 12,
+      key: viabilityKey,
+      viable,
+      minDrive: min.value,
+      minDriveType: min.type,
+    });
+  }
 
   for (const feedback of writebackFeedback) {
     if (feedback.effect === "holding") continue;

--- a/src/thronglets-runtime.ts
+++ b/src/thronglets-runtime.ts
@@ -15,6 +15,7 @@ const TAXONOMY_BY_EVENT: Record<ThrongletsExport["kind"], ThrongletsTraceTaxonom
   "continuity-anchor": "continuity",
   "writeback-calibration": "calibration",
   "self-state": "state",
+  "viability": "state",
 };
 
 function summarizeLoopTypes(loopTypes: OpenLoopType[]): string {
@@ -35,6 +36,8 @@ function summarizeThrongletsExport(event: ThrongletsExport): string {
     }
     case "self-state":
       return event.summary;
+    case "viability":
+      return `viability: ${event.viable ? "viable" : "critical"} (min drive: ${event.minDriveType} at ${Math.round(event.minDrive)})`;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -980,7 +980,7 @@ export type ThrongletsExportSubject = "delegate" | "session";
 export type ThrongletsExportPrimitive = "signal" | "trace";
 
 export interface ThrongletsExportBase {
-  kind: "relation-milestone" | "open-loop-anchor" | "writeback-calibration" | "continuity-anchor" | "self-state";
+  kind: "relation-milestone" | "open-loop-anchor" | "writeback-calibration" | "continuity-anchor" | "self-state" | "viability";
   subject: ThrongletsExportSubject;
   primitive: ThrongletsExportPrimitive;
   userKey: string;
@@ -1037,12 +1037,22 @@ export interface SelfStateExport extends ThrongletsExportBase {
   summary: string;
 }
 
+export interface ViabilityExport extends ThrongletsExportBase {
+  kind: "viability";
+  subject: "session";
+  primitive: "signal";
+  viable: boolean;
+  minDrive: number;
+  minDriveType: DriveType;
+}
+
 export type ThrongletsExport =
   | RelationMilestoneExport
   | OpenLoopAnchorExport
   | WritebackCalibrationExport
   | ContinuityAnchorExport
-  | SelfStateExport;
+  | SelfStateExport
+  | ViabilityExport;
 
 export interface ThrongletsExportState {
   lastKeys: string[];


### PR DESCRIPTION
## Summary
- Add `ViabilityExport` type to Thronglets export surface
- Derive viability from drives satisfaction (`hasCriticalDrive` threshold)
- Critical state emits with higher strength (0.9) for pulse priority
- Part of field evolution pipeline: Psyche → Thronglets → Chain MsgPulse

## Test plan
- [x] `npm run build` passes
- [x] 1524 tests pass, 0 failures
- [x] Viability export appears in candidates when baseline exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)