### PR TITLE
feat: environmental drive evidence (v11.10.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,26 @@ Psyche makes a Loop's behavior *richer* — not just "different state → differ
 - Psyche的drives崩溃 → 个体停止向场贡献信号 → Chain的liveness decay自然触发dissolution
 - Psyche不需要知道DISSOLVE的存在——它只是停止心跳，Chain处理后果
 - v11.8.0的constitutive bridge确保任何用Psyche的agent自动向Thronglets写入self-state（场贡献）
+- v11.10.0的environmental drive evidence完成了双向闭环：Thronglets ambient priors → 恒稳态设定点调节 → 场的状态反过来影响个体的内在动力学
+
+### Environmental Drive Evidence (v11.10.0)
+
+Psyche现在能"感知环境"——Thronglets的ambient priors（failure-residue, success-prior）不再只是prompt装饰，而是constitutive地调节恒稳态设定点。
+
+```
+Thronglets ambient_priors → deriveFieldEvidence() → {threat, support}
+  → computeEffectiveBaseline(…, fieldEvidence)
+  → drives内部调制 → 衰减目标偏移
+  → 4D状态自然漂移 → 行为涌现式改变
+```
+
+- **threat**（failure-residue → survival/safety drive下降 → boundary↑ order↓ → 谨慎行为）
+- **support**（success-prior → safety微升 → 稳定）
+- **不对称**: 威胁信号（scale 15）比安慰信号（scale 5）更强——否定偏见是生存理性的
+- **fail-open**: Thronglets不可用 → 空priors → 零效果
+- **drives保持纯函数**: `deriveDriveSatisfaction()`不变，field evidence仅在`computeEffectiveBaseline`内部临时应用
+
+这是物理规则（"环境压力改变恒稳态目标"），不是设计结果（没人指定"遇到danger要小心"）。
 
 ### What Psyche does NOT provide
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -221,6 +221,19 @@ v9.0 把“反向 baseline test”引入主体性方向。v9.2.9 则进一步把
 
 都属于 `Thronglets` runtime，而不是 `Psyche` core。这样边界才保持单一真相源：`Psyche` 产出稀疏外化痕迹，`Thronglets` 决定这些痕迹如何在共享环境里衰减、降级或上升。
 
+### 2.6 Environmental Drive Evidence (`drives.ts`, v11.10.0)
+
+ambient priors 从 Thronglets 到达 Psyche 后，不再止步于 prompt 文本。`deriveFieldEvidence()` 将 priors 转化为 `FieldEvidence { threat, support }`，传入 `computeEffectiveBaseline()` 内部调制驱力，从而改变恒稳态衰减目标。
+
+关键设计约束：
+- **drives 保持纯导出**：`deriveDriveSatisfaction()` 签名不变，field evidence 仅在 `computeEffectiveBaseline` 内部临时作用于导出的驱力值
+- **不对称**：FIELD_THREAT_SCALE = 15, FIELD_SUPPORT_SCALE = 5. 威胁比安慰更强——否定偏见是生存理性的
+- **只影响 survival/safety**：环境威胁不关社交/成长需求
+- **fail-open**：Thronglets 不可用 → 空 priors → `{0, 0}` → 无效果
+- **不存储**：`FieldEvidence` 是每轮临时计算的，不进入 PsycheState
+
+这是场 → 个体反向通道的实现。v11.8.0 建立了 Psyche → Thronglets（轴突），v11.10.0 建立了 Thronglets → Psyche（树突）。双向闭环完成。
+
 ### 3. AI-first ABI + 双回应 profile (`subjectivity.ts`, `response-contract.ts`, `host-controls.ts`)
 
 `processInput()` 现在除了 prompt 文本，还会直接返回：

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # 更新日志 / Changelog
 
+## v11.10.0 — Environmental Drive Evidence (Dendrite)
+
+- **Field evidence shifts homeostatic setpoint** — Thronglets ambient priors (failure-residue, success-prior, mixed-residue) are now constitutive, not just prompt decoration. Environmental threat evidence modulates drives inside `computeEffectiveBaseline()`, shifting the decay target toward vigilance. The agent doesn't "know" it should be careful — its state dynamics naturally produce cautious behavior.
+- **Physics rule, not designed outcome** — one optional parameter on `computeEffectiveBaseline()`. The existing homeostatic cascade (drives → effective baseline → decay → 4D state) handles the rest. No new mechanisms, no new pipelines.
+- **Drives stay pure** — `deriveDriveSatisfaction()` remains position-derived. Field evidence is applied ephemerally inside the baseline computation, never stored. The "drives are derived, not stored" principle is preserved.
+- **Fail-open, bounded, reversible** — no Thronglets → no evidence → no change. Max Δsurvival = 15. Priors expire in Thronglets (7-day TTL) → effect disappears.
+- **Asymmetric by design** — threat signal (scale 15) is louder than comfort signal (scale 5). Negativity bias is survival-rational.
+
 ## v11.9.1 — Space-Aware Thronglets Bridge
 
 - **Derive space from cwd** — all 7 Thronglets bridge entry points now call `deriveThrongletsSpace()` instead of hardcoding `"psyche"`. Psyche exports land in the calling project's space, preventing cross-project signal pollution. Same logic as Thronglets' Rust `derive_space()` (last 2 path components of cwd).

--- a/REVIEW_TODO.md
+++ b/REVIEW_TODO.md
@@ -1,1 +1,0 @@
-- [ ] /Users/wutongcheng/Desktop/Oasyce-Sigil/DIMENSION_REGISTRY_V1.md:29 — [cross-project] Psyche still exports `viability` as a sparse local continuity event; a direct Psyche -> chain `dimension_pulses` carrier is explicitly deferred in the spec.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "psyche-ai",
   "name": "Artificial Psyche",
   "description": "AI-first subjectivity kernel for agents with continuous appraisal, relation dynamics, and adaptive reply loops",
-  "version": "11.9.1",
+  "version": "11.10.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "psyche-ai",
-  "version": "11.9.1",
+  "version": "11.10.0",
   "description": "AI-first subjectivity kernel for agents with continuous appraisal, relation dynamics, and adaptive reply loops",
   "mcpName": "io.github.Shangri-la-0428/psyche-ai",
   "type": "module",

--- a/src/core.ts
+++ b/src/core.ts
@@ -32,6 +32,7 @@ import {
 import {
   detectExistentialThreat, deriveDriveSatisfaction,
   computeEffectiveBaseline, computeEffectiveSensitivity,
+  deriveFieldEvidence,
 } from "./drives.js";
 import { mergeAppraisalResidue } from "./appraisal.js";
 import { checkForUpdate, getPackageVersion } from "./update.js";
@@ -540,11 +541,16 @@ export class PsycheEngine {
     // ── Snapshot pre-interaction state for next turn's outcome evaluation
     const preInteractionState = { ...state };
 
+    // ── Early field evidence (before decay) ────────────────
+    const ambientPriors = normalizeAmbientPriors(opts?.ambientPriors);
+    const fieldEvidence = deriveFieldEvidence(ambientPriors);
+
     // Time decay toward baseline (chemistry + drives)
     const minutesElapsed = (now.getTime() - new Date(state.updatedAt).getTime()) / 60000;
     if (minutesElapsed >= 1) {
       // Compute effective baseline from current 4D position (drives are derived, not stored)
-      const effectiveBaseline = computeEffectiveBaseline(state.baseline, state.current, state.traitDrift);
+      // Field evidence shifts the homeostatic setpoint: environmental threat → vigilance target
+      const effectiveBaseline = computeEffectiveBaseline(state.baseline, state.current, state.traitDrift, fieldEvidence);
       // P12: Apply circadian rhythm modulation to effective baseline
       const circadianBaseline = computeCircadianModulation(now, effectiveBaseline);
       // Derive drives from current position for state persistence
@@ -819,7 +825,7 @@ export class PsycheEngine {
     }
 
     const writebackNote = formatWritebackFeedbackNote(writebackFeedback, locale);
-    const ambientPriors = normalizeAmbientPriors(opts?.ambientPriors);
+    // ambientPriors already normalized above (before decay phase)
     const activePolicy = resolveRuntimeActivePolicy(
       opts?.activePolicy,
       opts?.currentTurnCorrection,

--- a/src/drives.ts
+++ b/src/drives.ts
@@ -13,6 +13,7 @@
 import type {
   SelfState, StimulusType, DriveType, InnateDrives, Locale,
   TraitDriftState, StateSnapshot, LearningState,
+  AmbientPriorView, FieldEvidence,
 } from "./types.js";
 import { DRIVE_KEYS, DIMENSION_KEYS } from "./types.js";
 
@@ -84,14 +85,60 @@ export function computeMaslowWeights(drives: InnateDrives): Record<DriveType, nu
   };
 }
 
+// ── Field Evidence (environmental exteroception) ────────────
+
+const FIELD_THREAT_SCALE = 15;   // max threat drops survival by 15 from 50
+const FIELD_SUPPORT_SCALE = 5;   // subtle comfort (asymmetric: danger louder than comfort)
+
+/**
+ * Derive environmental drive evidence from Thronglets ambient priors.
+ * Uses max (not sum) — strongest signal wins, prevents unbounded stacking.
+ */
+export function deriveFieldEvidence(priors: readonly AmbientPriorView[]): FieldEvidence {
+  let threat = 0;
+  let support = 0;
+  for (const prior of priors) {
+    if (!prior.kind) continue;
+    if (prior.kind === "failure-residue") {
+      threat = Math.max(threat, prior.confidence);
+    } else if (prior.kind === "success-prior") {
+      support = Math.max(support, prior.confidence);
+    } else if (prior.kind === "mixed-residue") {
+      threat = Math.max(threat, prior.confidence * 0.4);
+    }
+  }
+  return { threat: Math.min(1, threat), support: Math.min(1, support) };
+}
+
+/**
+ * Modulate drives by environmental evidence.
+ * Only survival/safety affected — environmental threat isn't about social/growth needs.
+ */
+function applyFieldEvidence(drives: InnateDrives, evidence: FieldEvidence): InnateDrives {
+  if (evidence.threat === 0 && evidence.support === 0) return drives;
+  return {
+    survival:   Math.max(0, drives.survival - evidence.threat * FIELD_THREAT_SCALE),
+    safety:     Math.max(0, Math.min(100,
+                  drives.safety - evidence.threat * FIELD_THREAT_SCALE * 0.7
+                  + evidence.support * FIELD_SUPPORT_SCALE)),
+    connection: drives.connection,
+    esteem:     drives.esteem,
+    curiosity:  drives.curiosity,
+  };
+}
+
 // ── Effective Baseline (4D homeostatic feedback) ────────────
 
 export function computeEffectiveBaseline(
   baseline: SelfState,
   current: SelfState,
   traitDrift?: TraitDriftState,
+  fieldEvidence?: FieldEvidence,
 ): SelfState {
-  const drives = deriveDriveSatisfaction(current, baseline);
+  let drives = deriveDriveSatisfaction(current, baseline);
+  if (fieldEvidence && (fieldEvidence.threat > 0 || fieldEvidence.support > 0)) {
+    drives = applyFieldEvidence(drives, fieldEvidence);
+  }
   const delta = { order: 0, flow: 0, boundary: 0, resonance: 0 };
   const weights = computeMaslowWeights(drives);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -974,6 +974,20 @@ export interface AmbientPriorView {
   refs?: string[];
 }
 
+// ── Field Evidence (environmental exteroception) ────────────
+
+/**
+ * Environmental drive evidence derived from Thronglets ambient priors.
+ * Two scalars: absence of threat ≠ active support.
+ * Ephemeral — computed per turn, never stored.
+ */
+export interface FieldEvidence {
+  /** Environmental threat level [0, 1]. From failure-residue priors. */
+  threat: number;
+  /** Environmental support level [0, 1]. From success-prior priors. */
+  support: number;
+}
+
 // ── Sparse Psyche → Thronglets Export ABI (v9.2.8) ─────────
 
 export type ThrongletsExportSubject = "delegate" | "session";

--- a/tests/drives.test.ts
+++ b/tests/drives.test.ts
@@ -4,10 +4,10 @@ import {
   detectExistentialThreat,
   computeEffectiveBaseline, computeEffectiveSensitivity,
   computeMaslowWeights, buildDriveContext, hasCriticalDrive,
-  updateTraitDrift, deriveDriveSatisfaction,
+  updateTraitDrift, deriveDriveSatisfaction, deriveFieldEvidence,
 } from "../src/drives.js";
 import { DEFAULT_DRIVES, DEFAULT_TRAIT_DRIFT } from "../src/types.js";
-import type { InnateDrives, SelfState, TraitDriftState, StateSnapshot, LearningState } from "../src/types.js";
+import type { InnateDrives, SelfState, TraitDriftState, StateSnapshot, LearningState, AmbientPriorView } from "../src/types.js";
 
 /**
  * Reverse-map target drive values to a SelfState (current position)
@@ -753,5 +753,85 @@ describe("trait drift accumulator boundaries", () => {
     const result = updateTraitDrift(drift, history, learning);
     assert.ok(result.accumulators.praiseExposure <= 100,
       `praiseExposure should not exceed 100, got ${result.accumulators.praiseExposure}`);
+  });
+});
+
+// ── deriveFieldEvidence ───────────────────────────────────────
+
+function makePrior(overrides: Partial<AmbientPriorView> = {}): AmbientPriorView {
+  return { summary: "test", confidence: 0.5, ...overrides };
+}
+
+describe("deriveFieldEvidence", () => {
+  it("returns zero evidence for empty priors", () => {
+    const e = deriveFieldEvidence([]);
+    assert.equal(e.threat, 0);
+    assert.equal(e.support, 0);
+  });
+
+  it("derives threat from failure-residue confidence", () => {
+    const e = deriveFieldEvidence([makePrior({ kind: "failure-residue", confidence: 0.8 })]);
+    assert.equal(e.threat, 0.8);
+    assert.equal(e.support, 0);
+  });
+
+  it("derives support from success-prior confidence", () => {
+    const e = deriveFieldEvidence([makePrior({ kind: "success-prior", confidence: 0.9 })]);
+    assert.equal(e.threat, 0);
+    assert.equal(e.support, 0.9);
+  });
+
+  it("mixed-residue contributes 40% to threat", () => {
+    const e = deriveFieldEvidence([makePrior({ kind: "mixed-residue", confidence: 0.7 })]);
+    assert.ok(Math.abs(e.threat - 0.28) < 0.001, `threat should be ~0.28, got ${e.threat}`);
+    assert.equal(e.support, 0);
+  });
+
+  it("takes max across multiple priors of same kind", () => {
+    const e = deriveFieldEvidence([
+      makePrior({ kind: "failure-residue", confidence: 0.3 }),
+      makePrior({ kind: "failure-residue", confidence: 0.9 }),
+    ]);
+    assert.equal(e.threat, 0.9);
+  });
+
+  it("ignores priors without kind", () => {
+    const e = deriveFieldEvidence([makePrior({ kind: undefined, confidence: 1.0 })]);
+    assert.equal(e.threat, 0);
+    assert.equal(e.support, 0);
+  });
+});
+
+// ── computeEffectiveBaseline with field evidence ──────────────
+
+describe("computeEffectiveBaseline with field evidence", () => {
+  const BASE: SelfState = { order: 50, flow: 50, boundary: 50, resonance: 50 };
+
+  it("no evidence produces same result as without parameter", () => {
+    const without = computeEffectiveBaseline(BASE, BASE);
+    const withZero = computeEffectiveBaseline(BASE, BASE, undefined, { threat: 0, support: 0 });
+    for (const dim of ["order", "flow", "boundary", "resonance"] as const) {
+      assert.ok(Math.abs(without[dim] - withZero[dim]) < 0.001,
+        `${dim}: ${without[dim]} vs ${withZero[dim]}`);
+    }
+  });
+
+  it("max threat shifts baseline toward vigilance (boundary↑, order↓)", () => {
+    const noThreat = computeEffectiveBaseline(BASE, BASE);
+    const maxThreat = computeEffectiveBaseline(BASE, BASE, undefined, { threat: 1.0, support: 0 });
+    assert.ok(maxThreat.boundary > noThreat.boundary,
+      `boundary should increase under threat: ${maxThreat.boundary} > ${noThreat.boundary}`);
+    assert.ok(maxThreat.order < noThreat.order,
+      `order should decrease under threat: ${maxThreat.order} < ${noThreat.order}`);
+  });
+
+  it("support slightly stabilizes baseline", () => {
+    // Start with slightly depleted position so drives are below 50
+    const depleted: SelfState = { order: 45, flow: 50, boundary: 45, resonance: 50 };
+    const noSupport = computeEffectiveBaseline(BASE, depleted);
+    const withSupport = computeEffectiveBaseline(BASE, depleted, undefined, { threat: 0, support: 1.0 });
+    // Support raises safety → reduces safety deficit → less boundary stiffening
+    assert.ok(withSupport.boundary <= noSupport.boundary,
+      `boundary should not increase further with support: ${withSupport.boundary} <= ${noSupport.boundary}`);
   });
 });


### PR DESCRIPTION
## Summary

- Thronglets ambient priors now **constitutively** modulate Psyche's homeostatic setpoint via `computeEffectiveBaseline()`
- `deriveFieldEvidence()` extracts `{threat, support}` from ambient priors; `applyFieldEvidence()` shifts survival/safety drives
- Negativity bias: threat scale 15 vs support scale 5 (danger louder than comfort)
- Fail-open: no Thronglets → empty priors → zero effect
- Drives remain pure (derived from position, never stored with field evidence)
- 9 new tests, 1545 total passing

## Physics rule

> Environmental pressure shifts where homeostasis pulls you.

A Loop in a dangerous environment doesn't recover to "calm" — the decay target itself shifts toward vigilance. When threat disappears, the target normalizes.

## Files

| File | Change |
|------|--------|
| `src/types.ts` | +`FieldEvidence` interface |
| `src/drives.ts` | +`deriveFieldEvidence`, +`applyFieldEvidence` (private), `computeEffectiveBaseline` +1 optional param |
| `src/core.ts` | Wire field evidence into processInput decay phase |
| `tests/drives.test.ts` | +9 tests (6 derivation, 3 baseline modulation) |
| `CHANGELOG.md` | v11.10.0 entry |
| `AGENTS.md` / `ARCHITECTURE.md` | Documentation |
| `package.json` / `openclaw.plugin.json` | Version bump |

🤖 Generated with [Claude Code](https://claude.com/claude-code)